### PR TITLE
Update API e2e/integration tests

### DIFF
--- a/tests/testthat/test-api-end-to-end.R
+++ b/tests/testthat/test-api-end-to-end.R
@@ -49,6 +49,7 @@ test_that("Getting parties works", {
     "middle_name",
     "obs_count",
     "organization_name",
+    "party_label",
     "py_code",
     "salutation",
     "surname"
@@ -81,6 +82,7 @@ test_that("Getting references works", {
     "publisher",
     "reference_type",
     "rf_code",
+    "rf_label",
     "short_name",
     "title",
     "total_pages",
@@ -108,7 +110,7 @@ test_that("Getting cover methods works", {
     "cover_estimation_method",
     "cover_type",
     "rf_code",
-    "rf_name"
+    "rf_label"
   )
   names_nest <- c(
     names,
@@ -133,7 +135,7 @@ test_that("Getting stratum methods works", {
   expect_identical(nrow(zero_records), 0L)
   names <- c(
     "rf_code",
-    "rf_name",
+    "rf_label",
     "sm_code",
     "stratum_assignment",
     "stratum_method_description",
@@ -163,12 +165,12 @@ test_that("Getting plant concepts works", {
   expect_identical(nrow(zero_records), 0L)
   names <- c(
     "concept_rf_code",
-    "concept_rf_name",
+    "concept_rf_label",
     "current_accepted",
     "obs_count",
     "parent_name",
     "parent_pc_code",
-    "party",
+    "party_label",
     "pc_code",
     "plant_code",
     "plant_description",
@@ -179,7 +181,7 @@ test_that("Getting plant concepts works", {
     "start_date",
     "status",
     "status_rf_code",
-    "status_rf_name",
+    "status_rf_label",
     "stop_date"
   )
   names_nest <- c(
@@ -257,6 +259,7 @@ test_that("Getting taxon interpretations works", {
     "notes_public",
     "pc_code",
     "py_code",
+    "rf_code",
     "taxon_confidence",
     "taxon_fit",
     "ti_code",
@@ -267,7 +270,8 @@ test_that("Getting taxon interpretations works", {
     "author_obs_code",
     "author_plant_name",
     "ob_code",
-    "party",
+    "party_label",
+    "rf_label",
     "plant_code",
     "plant_label",
     "plant_name",
@@ -293,12 +297,12 @@ test_that("Getting community concepts works", {
   expect_identical(nrow(zero_records), 0L)
   names <- c(
     "concept_rf_code",
-    "concept_rf_name",
+    "concept_rf_label",
     "current_accepted",
     "obs_count",
     "parent_name",
     "parent_cc_code",
-    "party",
+    "party_label",
     "cc_code",
     "comm_code",
     "comm_description",
@@ -309,7 +313,7 @@ test_that("Getting community concepts works", {
     "start_date",
     "status",
     "status_rf_code",
-    "status_rf_name",
+    "status_rf_label",
     "stop_date"
   )
   names_nest <- c(
@@ -391,7 +395,7 @@ test_that("Getting community interpretations works", {
     "class_notes",
     "class_start_date",
     "class_stop_date",
-    "comm_authority_name",
+    "comm_authority_rf_label",
     "comm_code",
     "comm_framework",
     "comm_label",
@@ -451,6 +455,7 @@ test_that("Getting plot observations works", {
     "cm_code",
     "confidentiality_status",
     "cover_dispersion",
+    "cover_method_name",
     "date_accuracy",
     "date_entered",
     "dominant_stratum",
@@ -529,8 +534,10 @@ test_that("Getting plot observations works", {
     "pl_revisions",
     "plot_validation_level",
     "previous_ob_code",
+    "project_name",
     "representativeness",
     "rf_code",
+    "rf_label",
     "rock_type",
     "shape",
     "shore_distance",

--- a/tests/testthat/test-api-integration.R
+++ b/tests/testthat/test-api-integration.R
@@ -202,6 +202,7 @@ test_that("parties works", {
     "middle_name",
     "obs_count",
     "organization_name",
+    "party_label",
     "py_code",
     "salutation",
     "surname"
@@ -237,6 +238,7 @@ test_that("references works", {
     "publisher",
     "reference_type",
     "rf_code",
+    "rf_label",
     "short_name",
     "title",
     "total_pages",
@@ -264,7 +266,7 @@ test_that("cover-methods works", {
     "cover_estimation_method",
     "cover_type",
     "rf_code",
-    "rf_name"
+    "rf_label"
   )
   names_full_nest <- c(
     names_full,
@@ -290,7 +292,7 @@ test_that("stratum-methods works", {
   vb_code <- "sm.622"
   names_full <- c(
     "rf_code",
-    "rf_name",
+    "rf_label",
     "sm_code",
     "stratum_assignment",
     "stratum_method_description",
@@ -320,12 +322,12 @@ test_that("plant-concepts works", {
   vb_code <- "pc.193"
   names_full <- c(
     "concept_rf_code",
-    "concept_rf_name",
+    "concept_rf_label",
     "current_accepted",
     "obs_count",
     "parent_name",
     "parent_pc_code",
-    "party",
+    "party_label",
     "pc_code",
     "plant_code",
     "plant_description",
@@ -336,7 +338,7 @@ test_that("plant-concepts works", {
     "start_date",
     "status",
     "status_rf_code",
-    "status_rf_name",
+    "status_rf_label",
     "stop_date"
   )
   names_full_nest <- c(
@@ -418,6 +420,7 @@ test_that("taxon-interpretations works", {
     "notes_public",
     "pc_code",
     "py_code",
+    "rf_code",
     "taxon_confidence",
     "taxon_fit",
     "ti_code",
@@ -428,7 +431,8 @@ test_that("taxon-interpretations works", {
     "author_obs_code",
     "author_plant_name",
     "ob_code",
-    "party",
+    "party_label",
+    "rf_label",
     "plant_code",
     "plant_label",
     "plant_name",
@@ -458,12 +462,12 @@ test_that("community-concepts works", {
   vb_code <- "cc.1324"
   names_full <- c(
     "concept_rf_code",
-    "concept_rf_name",
+    "concept_rf_label",
     "current_accepted",
     "obs_count",
     "parent_name",
     "parent_cc_code",
-    "party",
+    "party_label",
     "cc_code",
     "comm_code",
     "comm_description",
@@ -474,7 +478,7 @@ test_that("community-concepts works", {
     "start_date",
     "status",
     "status_rf_code",
-    "status_rf_name",
+    "status_rf_label",
     "stop_date"
   )
   names_full_nest <- c(
@@ -570,7 +574,7 @@ test_that("community-interpretations works", {
     "class_notes",
     "class_start_date",
     "class_stop_date",
-    "comm_authority_name",
+    "comm_authority_rf_label",
     "comm_code",
     "comm_framework",
     "comm_label",
@@ -640,6 +644,7 @@ test_that("plot-observations works", {
     "cm_code",
     "confidentiality_status",
     "cover_dispersion",
+    "cover_method_name",
     "date_accuracy",
     "date_entered",
     "dominant_stratum",
@@ -718,8 +723,10 @@ test_that("plot-observations works", {
     "pl_revisions",
     "plot_validation_level",
     "previous_ob_code",
+    "project_name",
     "representativeness",
     "rf_code",
+    "rf_label",
     "rock_type",
     "shape",
     "shore_distance",


### PR DESCRIPTION
### What

This quick PR adds and/or updates a handful of fields across our API integration and E2E tests that run against the live API, in particular to align with recent API changes made in advance of the API 2.0.0-beta release (see vegbank2 [PR 210](https://github.com/NCEAS/vegbank2/pull/210) and [PR 212](https://github.com/NCEAS/vegbank2/pull/212).

No functional changes to the R package here -- only the test tweaks.

### Why

So that the tests once again have correct expectations of the API!

### How

Added and/or updated expected names in relevant tests.

### Testing

Verified that both test suites run successfully against the current API, as deployed to our dev environment.