### PR TITLE
Update getters for endpoints with new minimal detail option

### DIFF
--- a/R/vb_get.R
+++ b/R/vb_get.R
@@ -272,14 +272,15 @@ vb_get_plant_concepts <- function(vb_code = NULL, limit = 100, offset = 0,
 #' @export
 vb_get_taxon_observations <- function(vb_code = NULL, limit = 100,
                                       offset = 0, parquet = NULL,
-                                      search = NULL,
+                                      search = NULL, detail = NULL,
                                       with_nested = NULL, ...) {
   resource <- "taxon-observations"
   vb_key <- get_vb_key(resource)
   is_collection <- is.null(vb_code) || substr(vb_code, 1, 2) != vb_key
   if (missing(parquet)) parquet <- if (is_collection) TRUE else FALSE
+  if (missing(detail)) detail <- if (is_collection) "minimal" else "full"
   if (missing(with_nested)) with_nested <- if (is_collection) FALSE else TRUE
-  vb_get(resource, vb_code, parquet = parquet, search = search,
+  vb_get(resource, vb_code, parquet = parquet, search = search, detail = detail,
          with_nested = with_nested, limit = limit, offset = offset, ...)
 }
 

--- a/R/vb_get.R
+++ b/R/vb_get.R
@@ -302,13 +302,14 @@ vb_get_taxon_importances <- function(vb_code = NULL, limit = 100,
 #' @rdname vb_get
 #' @export
 vb_get_stem_counts <- function(vb_code = NULL, limit = 100, offset = 0,
-                               parquet = NULL, ...) {
+                               parquet = NULL, detail = NULL, ...) {
   resource <- "stem-counts"
   vb_key <- get_vb_key(resource)
   is_collection <- is.null(vb_code) || substr(vb_code, 1, 2) != vb_key
+  if (missing(detail)) detail <- if (is_collection) "minimal" else "full"
   if (missing(parquet)) parquet <- if (is_collection) TRUE else FALSE
   vb_get(resource, vb_code, parquet = parquet, limit = limit,
-         offset = offset, ...)
+         offset = offset, detail = detail, ...)
 }
 
 #' @rdname vb_get

--- a/R/vb_get.R
+++ b/R/vb_get.R
@@ -315,13 +315,14 @@ vb_get_stem_counts <- function(vb_code = NULL, limit = 100, offset = 0,
 #' @rdname vb_get
 #' @export
 vb_get_strata <- function(vb_code = NULL, limit = 100, offset = 0,
-                          parquet = NULL, ...) {
+                          parquet = NULL, detail = NULL,...) {
   resource <- "strata"
   vb_key <- get_vb_key(resource)
   is_collection <- is.null(vb_code) || substr(vb_code, 1, 2) != vb_key
+  if (missing(detail)) detail <- if (is_collection) "minimal" else "full"
   if (missing(parquet)) parquet <- if (is_collection) TRUE else FALSE
   vb_get(resource, vb_code, parquet = parquet, limit = limit,
-         offset = offset, ...)
+         offset = offset, detail = detail, ...)
 }
 
 #' @rdname vb_get

--- a/R/vb_get.R
+++ b/R/vb_get.R
@@ -287,15 +287,16 @@ vb_get_taxon_observations <- function(vb_code = NULL, limit = 100,
 #' @rdname vb_get
 #' @export
 vb_get_taxon_importances <- function(vb_code = NULL, limit = 100,
-                                     offset = 0, parquet = NULL,
+                                     offset = 0, parquet = NULL, detail = NULL,
                                      with_nested = NULL, ...) {
   resource <- "taxon-importances"
   vb_key <- get_vb_key(resource)
   is_collection <- is.null(vb_code) || substr(vb_code, 1, 2) != vb_key
   if (missing(parquet)) parquet <- if (is_collection) TRUE else FALSE
+  if (missing(detail)) detail <- if (is_collection) "minimal" else "full"
   if (missing(with_nested)) with_nested <- if (is_collection) FALSE else TRUE
-  vb_get(resource, vb_code, parquet = parquet, with_nested = with_nested,
-         limit = limit, offset = offset, ...)
+  vb_get(resource, vb_code, parquet = parquet, detail = detail,
+         with_nested = with_nested, limit = limit, offset = offset, ...)
 }
 
 #' @rdname vb_get

--- a/man/vb_get.Rd
+++ b/man/vb_get.Rd
@@ -98,6 +98,7 @@ vb_get_taxon_observations(
   offset = 0,
   parquet = NULL,
   search = NULL,
+  detail = NULL,
   with_nested = NULL,
   ...
 )
@@ -107,6 +108,7 @@ vb_get_taxon_importances(
   limit = 100,
   offset = 0,
   parquet = NULL,
+  detail = NULL,
   with_nested = NULL,
   ...
 )
@@ -116,10 +118,18 @@ vb_get_stem_counts(
   limit = 100,
   offset = 0,
   parquet = NULL,
+  detail = NULL,
   ...
 )
 
-vb_get_strata(vb_code = NULL, limit = 100, offset = 0, parquet = NULL, ...)
+vb_get_strata(
+  vb_code = NULL,
+  limit = 100,
+  offset = 0,
+  parquet = NULL,
+  detail = NULL,
+  ...
+)
 
 vb_get_taxon_interpretations(
   vb_code = NULL,

--- a/tests/testthat/test-api-end-to-end.R
+++ b/tests/testthat/test-api-end-to-end.R
@@ -249,34 +249,38 @@ test_that("Getting taxon observations works", {
     "No records returned",
     fixed = TRUE)
   expect_identical(nrow(zero_records), 0L)
-  names <- c(
-    "author_plant_name",
+  names_mini <- c(
     "int_curr_pc_code",
+    "int_orig_pc_code",
+    "ob_code",
+    "rf_code",
+    "taxon_inference_area",
+    "to_code"
+  )
+  names_full <- c(
+    names_mini,
+    "author_obs_code",
+    "author_plant_name",
     "int_curr_plant_code",
     "int_curr_plant_common",
     "int_curr_plant_sci_full",
     "int_curr_plant_sci_name_no_auth",
-    "int_orig_pc_code",
     "int_orig_plant_code",
     "int_orig_plant_common",
     "int_orig_plant_sci_full",
     "int_orig_plant_sci_name_no_auth",
-    "ob_code",
-    "rf_code",
-    "rf_label",
-    "taxon_inference_area",
-    "to_code"
+    "rf_label"
   )
-  names_nest <- c(
-    names,
+  names_full_nest <- c(
+    names_full,
     "taxon_importance"
   )
   one <- vb_get_taxon_observations("to.693826")
   expect_identical(nrow(one), 1L)
-  expect_named(one, names_nest, ignore.order = TRUE)
+  expect_named(one, names_full_nest, ignore.order = TRUE)
   all <- vb_get_taxon_observations(limit = 5)
   expect_identical(nrow(all), 5L)
-  expect_named(all, names, ignore.order = TRUE)
+  expect_named(all, names_mini, ignore.order = TRUE)
 })
 
 test_that("Getting taxon importances works", {

--- a/tests/testthat/test-api-end-to-end.R
+++ b/tests/testthat/test-api-end-to-end.R
@@ -332,7 +332,7 @@ test_that("Getting stem counts works", {
     "No records returned",
     fixed = TRUE)
   expect_identical(nrow(zero_records), 0L)
-  names <- c(
+  names_mini <- c(
     "count",
     "diameter",
     "diameter_accuracy",
@@ -341,17 +341,22 @@ test_that("Getting stem counts works", {
     "ob_code",
     "sc_code",
     "sr_code",
-    "stratum_name",
     "taxon_area",
     "tm_code",
     "to_code"
   )
+  names_full <- c(
+    names_mini,
+    "author_obs_code",
+    "author_plant_name",
+    "stratum_name"
+  )
   one <- vb_get_stem_counts("sc.2056")
   expect_identical(nrow(one), 1L)
-  expect_named(one, names, ignore.order = TRUE)
+  expect_named(one, names_full, ignore.order = TRUE)
   all <- vb_get_stem_counts(limit = 5)
   expect_identical(nrow(all), 5L)
-  expect_named(all, names, ignore.order = TRUE)
+  expect_named(all, names_mini, ignore.order = TRUE)
 })
 
 test_that("Getting strata works", {

--- a/tests/testthat/test-api-end-to-end.R
+++ b/tests/testthat/test-api-end-to-end.R
@@ -292,7 +292,7 @@ test_that("Getting taxon importances works", {
     "No records returned",
     fixed = TRUE)
   expect_identical(nrow(zero_records), 0L)
-  names <- c(
+  names_mini <- c(
     "basal_area",
     "biomass",
     "cover",
@@ -302,20 +302,25 @@ test_that("Getting taxon importances works", {
     "sr_code",
     "stratum_base",
     "stratum_height",
-    "stratum_name",
     "tm_code",
     "to_code"
   )
-  names_nest <- c(
-    names,
+  names_full <- c(
+    names_mini,
+    "author_obs_code",
+    "author_plant_name",
+    "stratum_name"
+  )
+  names_full_nest <- c(
+    names_full,
     "stems"
   )
   one <- vb_get_taxon_importances("tm.74081")
   expect_identical(nrow(one), 1L)
-  expect_named(one, names_nest, ignore.order = TRUE)
+  expect_named(one, names_full_nest, ignore.order = TRUE)
   all <- vb_get_taxon_importances(limit = 5)
   expect_identical(nrow(all), 5L)
-  expect_named(all, names, ignore.order = TRUE)
+  expect_named(all, names_mini, ignore.order = TRUE)
 })
 
 test_that("Getting stem counts works", {

--- a/tests/testthat/test-api-end-to-end.R
+++ b/tests/testthat/test-api-end-to-end.R
@@ -368,7 +368,7 @@ test_that("Getting strata works", {
     "No records returned",
     fixed = TRUE)
   expect_identical(nrow(zero_records), 0L)
-  names <- c(
+  names_mini <- c(
     "base",
     "cover",
     "description",
@@ -377,16 +377,20 @@ test_that("Getting strata works", {
     "ob_code",
     "sm_code",
     "sr_code",
-    "stratum_method_name",
-    "stratum_type_name",
     "sy_code"
+  )
+  names_full <- c(
+    names_mini,
+    "author_obs_code",
+    "stratum_method_name",
+    "stratum_type_name"
   )
   one <- vb_get_strata("sr.22374")
   expect_identical(nrow(one), 1L)
-  expect_named(one, names, ignore.order = TRUE)
+  expect_named(one, names_full, ignore.order = TRUE)
   all <- vb_get_strata(limit = 5)
   expect_identical(nrow(all), 5L)
-  expect_named(all, names, ignore.order = TRUE)
+  expect_named(all, names_mini, ignore.order = TRUE)
 })
 
 test_that("Getting taxon interpretations works", {

--- a/tests/testthat/test-api-integration.R
+++ b/tests/testthat/test-api-integration.R
@@ -388,23 +388,31 @@ test_that("taxon-observations works", {
   resource <- "taxon-observations"
   table_code <- "to"
   vb_code <- "to.587096"
-  names_full <- c(
-    "author_plant_name",
+  names_mini <- c(
     "int_curr_pc_code",
+    "int_orig_pc_code",
+    "ob_code",
+    "rf_code",
+    "taxon_inference_area",
+    "to_code"
+  )
+  names_full <- c(
+    names_mini,
+    "author_obs_code",
+    "author_plant_name",
     "int_curr_plant_code",
     "int_curr_plant_common",
     "int_curr_plant_sci_full",
     "int_curr_plant_sci_name_no_auth",
-    "int_orig_pc_code",
     "int_orig_plant_code",
     "int_orig_plant_common",
     "int_orig_plant_sci_full",
     "int_orig_plant_sci_name_no_auth",
-    "ob_code",
-    "rf_code",
-    "rf_label",
-    "taxon_inference_area",
-    "to_code"
+    "rf_label"
+  )
+  names_mini_nest <- c(
+    names_mini,
+    "taxon_importance"
   )
   names_full_nest <- c(
     names_full,
@@ -412,13 +420,15 @@ test_that("taxon-observations works", {
   )
   test_error_limit(resource)
   test_error_offset(resource)
-  test_error_detail(resource)
   test_error_vb_code(resource, table_code)
   test_success_one_json(resource, vb_code, names_full)
   test_success_one_parquet(resource, vb_code, names_full)
   test_success_collection_json(resource, names_full)
   test_success_collection_parquet(resource, names_full)
+  test_success_collection_parquet(resource, names_mini, detail="minimal")
   test_success_collection_parquet(resource, names_full_nest, with_nested=TRUE)
+  test_success_collection_parquet(resource, names_mini_nest,
+                                  detail="minimal", with_nested=TRUE)
   test_cross_resource(resource, "plot-observations", "ob.83802")
   test_cross_resource(resource, "plant-concepts", "pc.110944")
 })

--- a/tests/testthat/test-api-integration.R
+++ b/tests/testthat/test-api-integration.R
@@ -490,7 +490,7 @@ test_that("stem-counts works", {
   resource <- "stem-counts"
   table_code <- "sc"
   vb_code <- "sc.2056"
-  names_full <- c(
+  names_mini <- c(
     "count",
     "diameter",
     "diameter_accuracy",
@@ -499,19 +499,24 @@ test_that("stem-counts works", {
     "ob_code",
     "sc_code",
     "sr_code",
-    "stratum_name",
     "taxon_area",
     "tm_code",
     "to_code"
   )
+  names_full <- c(
+    names_mini,
+    "author_obs_code",
+    "author_plant_name",
+    "stratum_name"
+  )
   test_error_limit(resource)
   test_error_offset(resource)
-  test_error_detail(resource)
   test_error_vb_code(resource, table_code)
   test_success_one_json(resource, vb_code, names_full)
   test_success_one_parquet(resource, vb_code, names_full)
   test_success_collection_json(resource, names_full)
   test_success_collection_parquet(resource, names_full)
+  test_success_collection_parquet(resource, names_mini, detail="minimal")
   test_cross_resource(resource, "plot-observations", "ob.3062")
   test_cross_resource(resource, "taxon-observations", "to.68185")
   test_cross_resource(resource, "taxon-importances", "tm.74081")

--- a/tests/testthat/test-api-integration.R
+++ b/tests/testthat/test-api-integration.R
@@ -440,7 +440,7 @@ test_that("taxon-importances works", {
   resource <- "taxon-importances"
   table_code <- "tm"
   vb_code <- "tm.74081"
-  names_full <- c(
+  names_mini <- c(
     "basal_area",
     "biomass",
     "cover",
@@ -450,9 +450,18 @@ test_that("taxon-importances works", {
     "sr_code",
     "stratum_base",
     "stratum_height",
-    "stratum_name",
     "tm_code",
     "to_code"
+  )
+  names_full <- c(
+    names_mini,
+    "author_obs_code",
+    "author_plant_name",
+    "stratum_name"
+  )
+  names_mini_nest <- c(
+    names_mini,
+    "stems"
   )
   names_full_nest <- c(
     names_full,
@@ -460,13 +469,15 @@ test_that("taxon-importances works", {
   )
   test_error_limit(resource)
   test_error_offset(resource)
-  test_error_detail(resource)
   test_error_vb_code(resource, table_code)
   test_success_one_json(resource, vb_code, names_full)
   test_success_one_parquet(resource, vb_code, names_full)
   test_success_collection_json(resource, names_full)
   test_success_collection_parquet(resource, names_full)
+  test_success_collection_parquet(resource, names_mini, detail="minimal")
   test_success_collection_parquet(resource, names_full_nest, with_nested=TRUE)
+  test_success_collection_parquet(resource, names_mini_nest,
+                                  detail="minimal", with_nested=TRUE)
   test_cross_resource(resource, "plot-observations", "ob.3062")
   test_cross_resource(resource, "taxon-observations", "to.68185")
   test_cross_resource(resource, "plant-concepts", "pc.45236")

--- a/tests/testthat/test-api-integration.R
+++ b/tests/testthat/test-api-integration.R
@@ -529,7 +529,7 @@ test_that("strata works", {
   resource <- "strata"
   table_code <- "sr"
   vb_code <- "sr.22374"
-  names_full <- c(
+  names_mini <- c(
     "base",
     "cover",
     "description",
@@ -538,18 +538,22 @@ test_that("strata works", {
     "ob_code",
     "sm_code",
     "sr_code",
-    "stratum_method_name",
-    "stratum_type_name",
     "sy_code"
+  )
+  names_full <- c(
+    names_mini,
+    "author_obs_code",
+    "stratum_method_name",
+    "stratum_type_name"
   )
   test_error_limit(resource)
   test_error_offset(resource)
-  test_error_detail(resource)
   test_error_vb_code(resource, table_code)
   test_success_one_json(resource, vb_code, names_full)
   test_success_one_parquet(resource, vb_code, names_full)
   test_success_collection_json(resource, names_full)
   test_success_collection_parquet(resource, names_full)
+  test_success_collection_parquet(resource, names_mini, detail="minimal")
   test_cross_resource(resource, "plot-observations", "ob.109863")
   test_cross_resource(resource, "taxon-observations", "to.587096")
   test_cross_resource(resource, "taxon-importances", "tm.74081")

--- a/tests/testthat/test-vb_get_stem_counts.R
+++ b/tests/testthat/test-vb_get_stem_counts.R
@@ -17,7 +17,7 @@ with_mock_api({
     )
 
     response <- vb_get_stem_counts("sc.1", parquet=FALSE,
-      limit=NULL, offset=NULL)
+      limit=NULL, offset=NULL, detail=NULL)
     expect_s3_class(response, "data.frame")
     expect_identical(nrow(response), 1L)
     expect_named(
@@ -33,14 +33,14 @@ with_mock_api({
     expect_identical(response$stratum_name[1], "Canopy")
 
     expect_message(
-      zero_records <- vb_get_stem_counts(limit=0, parquet=FALSE),
+      zero_records <- vb_get_stem_counts(limit=0, parquet=FALSE, detail=NULL),
       "No records returned",
       fixed = TRUE
     )
     expect_s3_class(zero_records, "data.frame")
     expect_identical(nrow(zero_records), 0L)
 
-    response <- vb_get_stem_counts(limit=2, parquet=FALSE)
+    response <- vb_get_stem_counts(limit=2, parquet=FALSE, detail=NULL)
     expect_s3_class(response, "data.frame")
     expect_identical(nrow(response), 2L)
     expect_named(

--- a/tests/testthat/test-vb_get_strata.R
+++ b/tests/testthat/test-vb_get_strata.R
@@ -17,7 +17,7 @@ with_mock_api({
     )
 
     response <- vb_get_strata("sr.1", parquet=FALSE,
-      limit=NULL, offset=NULL)
+      limit=NULL, offset=NULL, detail=NULL)
     expect_s3_class(response, "data.frame")
     expect_identical(nrow(response), 1L)
     expect_named(
@@ -32,14 +32,14 @@ with_mock_api({
     expect_identical(response$stratum_type_name[1], "Shrub")
 
     expect_message(
-      zero_records <- vb_get_strata(limit=0, parquet=FALSE),
+      zero_records <- vb_get_strata(limit=0, parquet=FALSE, detail=NULL),
       "No records returned",
       fixed = TRUE
     )
     expect_s3_class(zero_records, "data.frame")
     expect_identical(nrow(zero_records), 0L)
 
-    response <- vb_get_strata(limit=2, parquet=FALSE)
+    response <- vb_get_strata(limit=2, parquet=FALSE, detail=NULL)
     expect_s3_class(response, "data.frame")
     expect_identical(nrow(response), 2L)
     expect_named(

--- a/tests/testthat/test-vb_get_taxon_importances.R
+++ b/tests/testthat/test-vb_get_taxon_importances.R
@@ -17,7 +17,7 @@ with_mock_api({
     )
 
     response <- vb_get_taxon_importances("tm.1", parquet=FALSE,
-      limit=NULL, offset=NULL, with_nested=NULL)
+      limit=NULL, offset=NULL, detail=NULL, with_nested=NULL)
     expect_s3_class(response, "data.frame")
     expect_identical(nrow(response), 2L)
     expect_named(
@@ -32,7 +32,7 @@ with_mock_api({
     expect_identical(response$stratum_name[1], "Nonvascular")
 
     response <- vb_get_taxon_importances(limit=2, parquet=FALSE,
-      with_nested=NULL)
+      detail=NULL, with_nested=NULL)
     expect_s3_class(response, "data.frame")
     expect_identical(nrow(response), 2L)
     expect_named(

--- a/tests/testthat/test-vb_get_taxon_observations.R
+++ b/tests/testthat/test-vb_get_taxon_observations.R
@@ -18,7 +18,7 @@ with_mock_api({
 
     expect_message(
       zero_records <- vb_get_taxon_observations("zero_records",
-        parquet=FALSE, limit=NULL, offset=NULL, with_nested=NULL),
+        parquet=FALSE, limit=NULL, offset=NULL, detail=NULL, with_nested=NULL),
       "No records returned",
       fixed = TRUE
     )
@@ -26,7 +26,7 @@ with_mock_api({
     expect_identical(nrow(zero_records), 0L)
 
     response <- vb_get_taxon_observations("to.693826", limit=NULL,
-      offset=NULL, with_nested = NULL)
+      offset=NULL, detail=NULL, with_nested = NULL)
     expect_s3_class(response, "data.frame")
     expect_identical(nrow(response), 1L)
     expect_named(


### PR DESCRIPTION
### What

This PR adds support for getting data with `detail="minimal"` for the following resource types that were recently updated in the VegBank API:
- Taxon observations
- Taxon importances
- Strata
- Stem counts

### Why

To keep `vegbankr` consistent with the API!

### How

- Added new `detail` argument to each of the relevant `vb_get_*()` functions, using the same default pattern used for this argument in other getters that already had it

### Documentation and testing
- Updated the `roxygen`-based documentation and generated a fresh `Rd` file
- Updated all tests a needed to align with the changes, including the live API tests
- Verified that all tests pass, and test coverage is 100% for related functions
- Verified that R `check` passes: `devtools::check(cran=TRUE, remote = TRUE, incoming = TRUE)`

### Demo

See extra columns returned for `detail="full"` vs new `detail="minimal"` view:

#### Taxon Observations
```r
setdiff(names(vb_get_taxon_observations(limit=1, detail="full")),
        names(vb_get_taxon_observations(limit=1, detail="minimal")))
# [1] "author_obs_code"                 "author_plant_name"
# [3] "int_curr_plant_code"             "int_curr_plant_sci_full"
# [5] "int_curr_plant_sci_name_no_auth" "int_curr_plant_common"
# [7] "int_orig_plant_code"             "int_orig_plant_sci_full"
# [9] "int_orig_plant_sci_name_no_auth" "int_orig_plant_common"
# [11] "rf_label"
```

#### Taxon Importances
```r
setdiff(names(vb_get_taxon_importances(limit=1, detail="full")),
        names(vb_get_taxon_importances(limit=1, detail="minimal")))
# [1] "author_obs_code"   "author_plant_name" "stratum_name"
```

#### Strata
```r
setdiff(names(vb_get_strata(limit=1, detail="full")),
        names(vb_get_strata(limit=1, detail="minimal")))
# [1] "author_obs_code"     "stratum_method_name" "stratum_type_name"
```

#### Stem counts
```r
setdiff(names(vb_get_stem_counts(limit=1, detail="full")),
        names(vb_get_stem_counts(limit=1, detail="minimal")))
# "author_obs_code"   "author_plant_name" "stratum_name"
```