### PR TITLE
Add docs and tests for search by vb_code

### DIFF
--- a/R/vb_get.R
+++ b/R/vb_get.R
@@ -20,8 +20,10 @@
 #'   between the two options. If not specified, defaults to `TRUE` for
 #'   collection queries and `FALSE` for single-record queries.
 #' @param search Optional search string for filtering results based on full-text
-#'   search. Available for: plot-observations, plant-concepts, community-concepts,
-#'   projects, and parties.
+#'   search or the resource's vb_code (the latter of which is functionally
+#'   equivalent to using the `vb_code` argument directly). Available for:
+#'   plot-observations, plant-concepts, community-concepts, projects, and
+#'   parties.
 #' @param sort Optional string for sorting results. Prepend with "-" for
 #'   descending order (e.g., "-obs_count"). Available for:
 #'   \itemize{

--- a/man/vb_get.Rd
+++ b/man/vb_get.Rd
@@ -219,8 +219,10 @@ between the two options. If not specified, defaults to \code{TRUE} for
 collection queries and \code{FALSE} for single-record queries.}
 
 \item{search}{Optional search string for filtering results based on full-text
-search. Available for: plot-observations, plant-concepts, community-concepts,
-projects, and parties.}
+search or the resource's vb_code (the latter of which is functionally
+equivalent to using the \code{vb_code} argument directly). Available for:
+plot-observations, plant-concepts, community-concepts, projects, and
+parties.}
 
 \item{sort}{Optional string for sorting results. Prepend with "-" for
 descending order (e.g., "-obs_count"). Available for:

--- a/tests/testthat/test-api-end-to-end.R
+++ b/tests/testthat/test-api-end-to-end.R
@@ -51,6 +51,11 @@ test_that("Getting projects works", {
   all <- vb_get_projects(limit = 5)
   expect_identical(nrow(all), 5L)
   expect_named(all, names, ignore.order = TRUE)
+  # check that search for pj code works
+  expect_identical(
+    vb_get_projects("pj.10508", parquet=TRUE),
+    vb_get_projects(search="pj.10508", detail="full") |>
+      dplyr::select(-search_rank))
 })
 
 test_that("Getting parties works", {
@@ -79,6 +84,11 @@ test_that("Getting parties works", {
   all <- vb_get_parties(limit = 5)
   expect_identical(nrow(all), 5L)
   expect_named(all, names, ignore.order = TRUE)
+  # check that search for py code works
+  expect_identical(
+    vb_get_parties("py.191378", parquet=TRUE),
+    vb_get_parties(search="py.191378", detail="full") |>
+      dplyr::select(-search_rank))
 })
 
 test_that("Getting roles works", {
@@ -237,7 +247,11 @@ test_that("Getting plant concepts works", {
   all <- vb_get_plant_concepts(limit = 5)
   expect_identical(nrow(all), 5L)
   expect_named(all, names, ignore.order = TRUE)
-
+  # check that search for pc code works
+  expect_identical(
+    vb_get_plant_concepts("pc.193", parquet=TRUE),
+    vb_get_plant_concepts(search="pc.193", detail="full", with_nested=TRUE) |>
+      dplyr::select(-search_rank))
 })
 
 test_that("Getting taxon observations works", {
@@ -483,6 +497,12 @@ test_that("Getting community concepts works", {
   all <- vb_get_community_concepts(limit = 5)
   expect_identical(nrow(all), 5L)
   expect_named(all, names, ignore.order = TRUE)
+  # check that search for cc code works
+  expect_identical(
+    vb_get_community_concepts("cc.30617", parquet=TRUE),
+    vb_get_community_concepts(search="cc.30617", detail="full",
+                              with_nested=TRUE) |>
+      dplyr::select(-search_rank))
 })
 
 test_that("Getting community classifications works", {
@@ -805,4 +825,10 @@ test_that("Getting plot observations works", {
   all <- vb_get_plot_observations(limit = 5)
   expect_identical(nrow(all), 5L)
   expect_named(all, names_mini, ignore.order = TRUE)
+  # check that search for ob code works
+  expect_identical(
+    vb_get_plot_observations("ob.41618", parquet=TRUE),
+    vb_get_plot_observations(search="ob.41618", detail="full",
+                             with_nested=TRUE, num_taxa=1000) |>
+      dplyr::select(-search_rank))
 })


### PR DESCRIPTION
### What

This small PR updates `vb_get()` documentation and adds some API end-to-end tests corresponding to the [recent API change](https://github.com/NCEAS/vegbank2/pull/366) allowing `search` terms to include the desired resource's vb code.

### Why

Mostly because I wanted to add the API e2e tests confirming that searching by vb_code is the same as passing it via the `vb_code` argument. Figured I might as well document this change while I'm at it, although users should generally use the `vb_code` argument directly rather than leveraging this behavior in search. The new API functionality is there really to support a front end (web ui) use case by making search more general.

### How

Docs & test changes only! See below.

### Documentation and testing
- Updated the `roxygen`-based documentation and generated a fresh `Rd` file
- Added test cases to the API e2e test suite, and verified that they pass
- Verified that R `check` passes: `devtools::check(cran=TRUE, remote = TRUE, incoming = TRUE)`